### PR TITLE
Mudando email padrão para recuperação de senha

### DIFF
--- a/monitoria/settings.py
+++ b/monitoria/settings.py
@@ -41,7 +41,7 @@ ACCOUNT_AUTHENTICATION_METHOD = 'email'
 #ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_UNIQUE_EMAIL = True 
+ACCOUNT_UNIQUE_EMAIL = True
 
 AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
@@ -113,7 +113,7 @@ ROOT_URLCONF = 'monitoria.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ['templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/templates/registration/password_reset_email.html
+++ b/templates/registration/password_reset_email.html
@@ -1,0 +1,7 @@
+Você está recebendo este e-mail porque solicitou uma redefinição de senha para sua conta de usuário no aplicativo Monitoria FGA.
+
+Por favor, vá para a página seguinte e escolha uma nova senha:
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+Obrigado por usar nosso app!
+
+Equipe Monitoria FGA.

--- a/templates/registration/password_reset_subject.txt
+++ b/templates/registration/password_reset_subject.txt
@@ -1,0 +1,1 @@
+Redefinir senha Monitoria FGA


### PR DESCRIPTION
## Descrição 

Pull request referente a parte da issue [E-mail de recuperacao de senha](https://github.com/2019-2-arquitetura-desenho/monitoria-api/issues/16). 

## Como rodar 
Com um usuário criado acesse a pagina <http://localhost:8000/password_reset/> e insira as informacoes pedidas. Veja e e-mail no terminal.