### PR TITLE
Feature/email and env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 .vscode/
 .idea/
+
+# static_files
+static_files/

--- a/env-reference
+++ b/env-reference
@@ -1,1 +1,3 @@
-DOMAIN=LINK DO DOMINIO(i.e. localhost:8000)
+DOMAIN=localhost:8000
+PASSWORD_EMAIL=NeedToBeSetInEnvFile
+SECRET_KEY=o^gxy879i$y^k+r1lo%*!0(-^er)jnos9qtg$zm%qs&de03n&!

--- a/monitoria/settings.py
+++ b/monitoria/settings.py
@@ -8,7 +8,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Env
 env = environ.Env(
     # set casting, default value
-    DOMAIN=(str, "localhost:8000")
+    DOMAIN=(str, "localhost:8000"),
+    PASSWORD_EMAIL=(str, "NeedToBeSetInEnvFile"),
+    SECRET_KEY=(str, "o^gxy879i$y^k+r1lo%*!0(-^er)jnos9qtg$zm%qs&de03n&!"),
 )
 environ.Env.read_env(os.path.join(BASE_DIR, '.env'))
 DOMAIN = env('DOMAIN')
@@ -17,7 +19,7 @@ DOMAIN = env('DOMAIN')
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'o^gxy879i$y^k+r1lo%*!0(-^er)jnos9qtg$zm%qs&de03n&!'
+SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -45,7 +47,16 @@ INSTALLED_APPS = [
 ]
 SITE_ID = 1
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+if DEBUG:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+else:
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+    EMAIL_HOST = 'smtp.gmail.com'
+    EMAIL_PORT = 587
+    EMAIL_HOST_USER = 'amonitoriafga@gmail.com'
+    EMAIL_HOST_PASSWORD = env('PASSWORD_EMAIL')
+    EMAIL_USE_TLS = True
+    DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 ACCOUNT_AUTHENTICATION_METHOD = 'email'
 #ACCOUNT_USER_MODEL_USERNAME_FIELD = None

--- a/monitoria/settings.py
+++ b/monitoria/settings.py
@@ -22,7 +22,7 @@ DOMAIN = env('DOMAIN')
 SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 # Application definition

--- a/monitoria/settings.py
+++ b/monitoria/settings.py
@@ -22,7 +22,7 @@ DOMAIN = env('DOMAIN')
 SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 # Application definition
@@ -127,6 +127,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'monitoria.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django-rest-auth>=0.0 ,<1.0
 djangorestframework-jwt>=1.0, <2.0
 PyJWT>=1.0, <2.0
 django-environ>=0.4, <1.0
+whitenoise>=4.1, <5.0

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -1,4 +1,5 @@
 {% load i18n static %}
+{% load static %}
 <style>
 .login-page {
   width: 360px;

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -1,4 +1,5 @@
 {% load i18n static %}
+{% load static %}
 <style>
 .login-page {
   width: 360px;

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -1,4 +1,5 @@
 {% load i18n static %}
+{% load static %}
 <style>
 .login-page {
   width: 360px;

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -1,4 +1,5 @@
 {% load i18n static %}
+{% load static %}
 <style>
 .login-page {
   width: 360px;


### PR DESCRIPTION
## Descrição 

Pull request referente a parte da issue [Teste com E-mail real e informacoes sensiveis](https://github.com/2019-2-arquitetura-desenho/monitoria-api/issues/24). 

## Como rodar 

Limpe a imagem do docker para melhores testes, rode o server normalmente, adicione um arquivo ".env" no mesmo path do "env-reference" e adicione as informacoes necessarias (Foram disponibilizadas em outro meio de conversa por serem sensiveis). Abra o bash e execute o collectstatic.

## Obs

* Rode o servidor com DEBUG=False **E** com DEBUG=True e teste as funcionalidades em geral e verifique se alguma informacao sensivel ainda esta exposta... Com DEBUG=True deveria chegar e-mail re criacao de conta e password reset via email e com DEBUG=False aparece no terminal