### PR TITLE
Bugfix relativo ao Leitor de PDF

### DIFF
--- a/pdf_reader/LeitorPDF.py
+++ b/pdf_reader/LeitorPDF.py
@@ -136,15 +136,15 @@ class Download():
             os.remove("tmp.pdf")
         if(os.path.isfile('./tmp (1).pdf')):
             os.remove("tmp (1).pdf")
-        wget.download(url,'./tmp.pdf')
+        wget.download(url, './tmp.pdf')
         local = './tmp.pdf'
         return local
 
     def XMLdownload(url):
-        if(os.path.isfile('./tmp.xml)):
+        if(os.path.isfile('./tmp.xml ')):
             os.remove("tmp.xml ")
         if(os.path.isfile('./tmp (1).xml')):
-            os.remove("tmp (1).xml")
+            os.remove("tmp (1).xml ")
         wget.download(url, './tmp.xml')
         local = './tmp.xml'
         return local

--- a/pdf_reader/LeitorPDF.py
+++ b/pdf_reader/LeitorPDF.py
@@ -1,6 +1,6 @@
 import pdftotext
 import wget
-# import os
+import os
 import re
 from abc import ABC, abstractmethod
 # import json
@@ -132,11 +132,19 @@ def extract_code(pdf_extractor: Extractor):
 
 class Download():
     def PDFdownload(url):
-        wget.download(url, './tmp.pdf')
+        if(os.path.isfile('./tmp.pdf')):
+            os.remove("tmp.pdf")
+        if(os.path.isfile('./tmp (1).pdf')):
+            os.remove("tmp (1).pdf")
+        wget.download(url,'./tmp.pdf')
         local = './tmp.pdf'
         return local
 
     def XMLdownload(url):
+        if(os.path.isfile('./tmp.xml)):
+            os.remove("tmp.xml ")
+        if(os.path.isfile('./tmp (1).xml')):
+            os.remove("tmp (1).xml")
         wget.download(url, './tmp.xml')
         local = './tmp.xml'
         return local


### PR DESCRIPTION
## Descrição 
Pull request referente a issue [Bug - Criar usuário com url de pdf inválido](https://github.com/2019-2-arquitetura-desenho/monitoria-api/issues/40#issue-523734062).

## Como rodar 
Rode o servidor. Crie um usuário na url < localhost:8000/registration > com 'email', 'password' e 'pdf_url' como keys no body, sendo o pdf_url uma url válida, e logo após crie outro usuário com o pdf_url inválido.

## Obs
