### PR TITLE
Refatorar set_profile de acordo com o Principio da Responsabilidade Única

### DIFF
--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
     path('professor_classes/', views.professor_classes),
     path('get_student/', views.get_student),
     path('set_student/', views.set_student),
+    path('create_profile/', views.create_profile),
 ]


### PR DESCRIPTION
# Descrição

Corrige a nomeclatura dos enpoints `set_profile` (agora apenas altera o profile, não cria), adiconando um enpoint `create_profile` apenas para uso interno.

Co-authored-by: Ivan Dobbin <ivandinizdobbin2@gmail.com>